### PR TITLE
ci: upgrade Docker workflow actions to Node24 and fix prod tagging

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,6 +7,15 @@ permissions:
 on:
   push:
     branches: [ production, test ]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to tag for image publish
+        required: true
+        type: choice
+        options:
+          - production
+          - test
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,22 +23,24 @@ concurrency:
 
 jobs:
   docker-build-push:
-    # Run on PRs to production/test OR manual trigger
+    # Run on pushes to production/test OR manual trigger
     name: docker / build-and-push
-    if: contains(fromJson('["production", "test"]'), github.ref_name)
+    if: |
+      (github.event_name == 'workflow_dispatch' && contains(fromJson('["production", "test"]'), inputs.branch)) ||
+      contains(fromJson('["production", "test"]'), github.ref_name)
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -40,10 +51,13 @@ jobs:
         run: |
           echo "github.event_name=${{ github.event_name }}"
           echo "github.base_ref=${GITHUB_BASE_REF}"
+          echo "github.ref_name=${GITHUB_REF_NAME}"
           echo "inputs.branch=${{ inputs.branch }}"
 
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             TARGET_BRANCH="${{ inputs.branch }}"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            TARGET_BRANCH="${GITHUB_REF_NAME}"
           else
             TARGET_BRANCH="${GITHUB_BASE_REF}"
           fi
@@ -58,7 +72,7 @@ jobs:
 
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
Upgrade GitHub Actions to current Node24-based majors:\n- actions/checkout v4 -> v7\n- docker/setup-buildx-action v3 -> v4\n- docker/login-action v3 -> v4\n- docker/build-push-action v5 -> v7\n\nFix branch-to-tag resolution so push events use GITHUB_REF_NAME instead of empty GITHUB_BASE_REF, which previously caused production pushes to publish the test tag.\n\nAdd workflow_dispatch branch input (production/test) and gate manual runs using the selected input branch.